### PR TITLE
Python cache files mark submodule as dirty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Python cache
+__pycache__
+*.pyc


### PR DESCRIPTION
When this is ran by AppDaemon pycache files are created. These should be ignored. My particular use case is to run the app as a submodule within an existing docker-compose repo.