### PR TITLE
fix: Updating examples for AppDaemon 3.0

### DIFF
--- a/occusim.py
+++ b/occusim.py
@@ -1,4 +1,4 @@
-import appdaemon.appapi as appapi
+import appdaemon.plugins.hass.hassapi as hass
 import datetime
 import re
 import random
@@ -10,7 +10,7 @@ import random
 __version__ = "1.1.5"
 
 
-class OccuSim(appapi.AppDaemon):
+class OccuSim(hass.Hass):
 
     def initialize(self):
 


### PR DESCRIPTION
As of AppDaemon 3.0, namespaces have been introduced to make it
possible to handle multiple instances of the same plugin.  These
changes bring the upstream in-line with the version from the
examples repository.

This change should be congruent with the changes in
home-assistant/appdaemon@6f97b5927e3b7b64902d474a3e8aed00024612f8