### PR TITLE
 Added option to specify notify service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Occupancy Simulator:
 ```
 
 - `log_msg` set this to any value to make `OccuSim` log its scheduled activities
-- `notify` set this to any value to make `OccuSim` send a notification for its scheduled activities
+- `notify` set this to any value to make `OccuSim` send a notification for its scheduled activities to the default notify.notify service in Home Assistant
+- `notify_service` sets the override for the notify service to be used, for instance `telegram` or `smtp` 
 - `enable` (optional) set to the name of an input boolean, and the value it needs to be to enable `OccuSim`. If omitted, `OccuSim` will always be active.
-- 1select` (optional) set the name of an input select that will have its value checked at execution time. If the current state of the input select matches any of the listed states, occusim will be active. e.g.: `select: input_select.mode,Day,Night`
+- `1select` (optional) set the name of an input select that will have its value checked at execution time. If the current state of the input select matches any of the listed states, occusim will be active. e.g.: `select: input_select.mode,Day,Night`
 - `test` (optional) set to "1" to have occusim run, but not activate any lights or scenes. Use with `log_msg` to test settings and times. If set to anything else, or not present, test mode will not be enabled.
 - `dump_times` (optional) set to any value to dump a list of the times events will happen when the app is first initialized and every night at the reset time.
 - `reset_time` (optional) time at which `OccuSim` re-calculates the new set of random times for the day ahead. Defaults to 3am.

--- a/occusim.py
+++ b/occusim.py
@@ -7,7 +7,7 @@ import random
 # App to simulate occupancy in an empty house
 #
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 
 
 class OccuSim(hass.Hass):
@@ -250,6 +250,9 @@ class OccuSim(hass.Hass):
         if "log_msg" in self.args:
             self.log(message)
         if "notify" in self.args:
-            self.notify(message)
+            if "notify_protocol" in self.args:
+                self.notify(message, name=self.args['notify_service'])
+            else:
+                self.notify(message)
 
 


### PR DESCRIPTION
Occusim uses the default notify.notify service. This adds the options to specify another notify service.